### PR TITLE
Broken Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "jspm": {
     "dependencies": {
-      "css": "css",
+      "css": "npm:jspm-loader-css",
       "froala-editor": "npm:froala-editor@^2.3.3",
       "jquery": "npm:jquery@^2.2.4",
       "font-awesome": "npm:font-awesome@^4.6.3"


### PR DESCRIPTION
Appears that jspm doesn't like:
`"css": "css"`
it isn't an proper NPM format. Changed to:
`npm:jspm-loader-css`