### PR TITLE
Froala 3 fixes

### DIFF
--- a/dist/amd/froala-editor.js
+++ b/dist/amd/froala-editor.js
@@ -63,7 +63,7 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 		throw new Error('Decorating class property failed. Please ensure that transform-class-properties is enabled.');
 	}
 
-	var _dec, _dec2, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3;
+	var _dec, _dec2, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4;
 
 	var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.customElement)('froala-editor'), _dec2 = (0, _aureliaFramework.inject)(Element, _froalaEditorConfig.Config, _aureliaBinding.ObserverLocator), _dec(_class = _dec2(_class = (_class2 = function () {
 		function FroalaEditor1(element, config, observerLocator) {
@@ -74,6 +74,8 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 			_initDefineProp(this, 'config', _descriptor2, this);
 
 			_initDefineProp(this, 'eventHandlers', _descriptor3, this);
+
+			_initDefineProp(this, 'instance', _descriptor4, this);
 
 			this.element = element;
 
@@ -156,5 +158,8 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 		initializer: function initializer() {
 			return {};
 		}
+	}), _descriptor4 = _applyDecoratedDescriptor(_class2.prototype, 'instance', [_aureliaFramework.bindable], {
+		enumerable: true,
+		initializer: null
 	})), _class2)) || _class) || _class);
 });

--- a/dist/amd/froala-editor.js
+++ b/dist/amd/froala-editor.js
@@ -75,7 +75,7 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 
 			_initDefineProp(this, 'eventHandlers', _descriptor3, this);
 
-			_initDefineProp(this, 'instance', _descriptor4, this);
+			_initDefineProp(this, 'editor', _descriptor4, this);
 
 			this.element = element;
 			this.config = config.options();
@@ -91,23 +91,23 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 
 			var editorSelector = this.config.iframe ? 'textarea' : 'div';
 
-			if (this.instance != null) {
+			if (this.editor != null) {
 				return;
 			}
 
 			this.subscriptions = [this.observerLocator.getObserver(this, 'value').subscribe(function (newValue, oldValue) {
-				if (_this.instance && _this.instance.html.get() != newValue) {
-					_this.instance.html.set(newValue);
+				if (_this.editor && _this.editor.html.get() != newValue) {
+					_this.editor.html.set(newValue);
 				}
 			})];
 
-			this.instance = new _froala_editorPkgdMin2.default('#' + this.element.id + ' ' + editorSelector, Object.assign({}, this.config), function () {
-				_this.instance.html.set(_this.value);
+			this.editor = new _froala_editorPkgdMin2.default('#' + this.element.id + ' ' + editorSelector, Object.assign({}, this.config), function () {
+				_this.editor.html.set(_this.value);
 
 				if (_this.eventHandlers && _this.eventHandlers.length != 0) {
 					var _loop = function _loop(eventHandlerName) {
 						var handler = _this.eventHandlers[eventHandlerName];
-						_this.instance.events.on('' + eventHandlerName, function () {
+						_this.editor.events.on('' + eventHandlerName, function () {
 							for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
 								args[_key] = arguments[_key];
 							}
@@ -120,19 +120,19 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 						_loop(eventHandlerName);
 					}
 				}
-				_this.instance.events.on('blur', function (e) {
-					return _this.value = _this.instance.html.get();
+				_this.editor.events.on('blur', function (e) {
+					return _this.value = _this.editor.html.get();
 				});
-				_this.instance.events.on('contentChanged', function (e) {
-					return _this.value = _this.instance.html.get();
+				_this.editor.events.on('contentChanged', function (e) {
+					return _this.value = _this.editor.html.get();
 				});
 			});
 		};
 
 		FroalaEditor1.prototype.detached = function detached() {
-			if (this.instance != null) {
-				this.instance.destroy();
-				this.instance = null;
+			if (this.editor != null) {
+				this.editor.destroy();
+				this.editor = null;
 			}
 		};
 
@@ -150,7 +150,7 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 		initializer: function initializer() {
 			return {};
 		}
-	}), _descriptor4 = _applyDecoratedDescriptor(_class2.prototype, 'instance', [_aureliaFramework.bindable], {
+	}), _descriptor4 = _applyDecoratedDescriptor(_class2.prototype, 'editor', [_aureliaFramework.bindable], {
 		enumerable: true,
 		initializer: null
 	})), _class2)) || _class) || _class);

--- a/dist/amd/froala-editor.js
+++ b/dist/amd/froala-editor.js
@@ -92,9 +92,8 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 			var _this = this;
 
 			var editorSelector = this.config.iframe ? 'textarea' : 'div';
-			this.instance = this.element.querySelector(editorSelector);
 
-			if (this.instance['data-froala.editor']) {
+			if (this.instance != null) {
 				return;
 			}
 
@@ -133,11 +132,10 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 		};
 
 		FroalaEditor1.prototype.tearDown = function tearDown() {
-			if (this.instance && this.instance['data-froala.editor']) {
+			if (this.instance != null) {
 				this.instance.destroy();
+				this.instance = null;
 			}
-
-			this.instance = null;
 		};
 
 		FroalaEditor1.prototype.attached = function attached() {

--- a/dist/amd/froala-editor.js
+++ b/dist/amd/froala-editor.js
@@ -91,11 +91,8 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 		FroalaEditor1.prototype.tearUp = function tearUp() {
 			var _this = this;
 
-			if (this.config.iframe) {
-				this.instance = this.element.getElementsByTagName('textarea')[0];
-			} else {
-				this.instance = this.element.getElementsByTagName('div')[0];
-			}
+			var editorSelector = this.config.iframe ? 'textarea' : 'div';
+			this.instance = this.element.querySelector(editorSelector);
 
 			if (this.instance['data-froala.editor']) {
 				return;
@@ -107,7 +104,7 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 				}
 			})];
 
-			this.instance = new _froala_editorPkgdMin2.default('#' + this.element.id + ' div', Object.assign({}, this.config), function () {
+			this.instance = new _froala_editorPkgdMin2.default('#' + this.element.id + ' ' + editorSelector, Object.assign({}, this.config), function () {
 				_this.instance.html.set(_this.value);
 
 				if (_this.eventHandlers && _this.eventHandlers.length != 0) {

--- a/dist/amd/froala-editor.js
+++ b/dist/amd/froala-editor.js
@@ -67,8 +67,6 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 
 	var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.customElement)('froala-editor'), _dec2 = (0, _aureliaFramework.inject)(Element, _froalaEditorConfig.Config, _aureliaBinding.ObserverLocator), _dec(_class = _dec2(_class = (_class2 = function () {
 		function FroalaEditor1(element, config, observerLocator) {
-			var _this = this;
-
 			_classCallCheck(this, FroalaEditor1);
 
 			_initDefineProp(this, 'value', _descriptor, this);
@@ -81,15 +79,11 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 
 			this.config = config.options();
 
-			this.subscriptions = [observerLocator.getObserver(this, 'value').subscribe(function (newValue, oldValue) {
-				if (_this.instance && _this.instance.html.get() != newValue) {
-					_this.instance.html(newValue);
-				}
-			})];
+			this.observerLocator = observerLocator;
 		}
 
 		FroalaEditor1.prototype.tearUp = function tearUp() {
-			var _this2 = this;
+			var _this = this;
 
 			if (this.config.iframe) {
 				this.instance = this.element.getElementsByTagName('textarea')[0];
@@ -103,10 +97,16 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 
 			this.instance.innerHTML = this.value;
 
+			this.subscriptions = [this.observerLocator.getObserver(this, 'value').subscribe(function (newValue, oldValue) {
+				if (_this.instance && _this.instance.html.get() != newValue) {
+					_this.instance.html.set(newValue);
+				}
+			})];
+
 			if (this.eventHandlers && this.eventHandlers.length != 0) {
 				var _loop = function _loop(eventHandlerName) {
-					var handler = _this2.eventHandlers[eventHandlerName];
-					_this2.instance.addEventListener('' + eventHandlerName, function () {
+					var handler = _this.eventHandlers[eventHandlerName];
+					_this.instance.addEventListener('' + eventHandlerName, function () {
 						var p = arguments;
 						return handler.apply(this, p);
 					});
@@ -117,10 +117,10 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 				}
 			}
 			this.instance.addEventListener('contentChanged', function (e, editor) {
-				return _this2.value = editor.html.get();
+				return _this.value = editor.html.get();
 			});
 			this.instance.addEventListener('blur', function (e, editor) {
-				return _this2.value = editor.html.get();
+				return _this.value = editor.html.get();
 			});
 
 			this.instance = new _froala_editorPkgdMin2.default('#' + this.element.id, Object.assign({}, this.config));

--- a/dist/amd/froala-editor.js
+++ b/dist/amd/froala-editor.js
@@ -84,6 +84,10 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 			this.observerLocator = observerLocator;
 		}
 
+		FroalaEditor1.prototype.bind = function bind(bindingContext, overrideContext) {
+			this.parent = bindingContext;
+		};
+
 		FroalaEditor1.prototype.tearUp = function tearUp() {
 			var _this = this;
 
@@ -105,27 +109,30 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 				}
 			})];
 
-			if (this.eventHandlers && this.eventHandlers.length != 0) {
-				var _loop = function _loop(eventHandlerName) {
-					var handler = _this.eventHandlers[eventHandlerName];
-					_this.instance.addEventListener('' + eventHandlerName, function () {
-						var p = arguments;
-						return handler.apply(this, p);
-					});
-				};
+			this.instance = new _froala_editorPkgdMin2.default('#' + this.element.id + ' div', Object.assign({}, this.config), function () {
+				if (_this.eventHandlers && _this.eventHandlers.length != 0) {
+					var _loop = function _loop(eventHandlerName) {
+						var handler = _this.eventHandlers[eventHandlerName];
+						_this.instance.events.on('' + eventHandlerName, function () {
+							for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+								args[_key] = arguments[_key];
+							}
 
-				for (var eventHandlerName in this.eventHandlers) {
-					_loop(eventHandlerName);
+							return handler.apply(_this.parent, args);
+						});
+					};
+
+					for (var eventHandlerName in _this.eventHandlers) {
+						_loop(eventHandlerName);
+					}
 				}
-			}
-			this.instance.addEventListener('contentChanged', function (e, editor) {
-				return _this.value = editor.html.get();
+				_this.instance.events.on('blur', function (e) {
+					return _this.value = _this.instance.html.get();
+				});
+				_this.instance.events.on('contentChanged', function (e) {
+					return _this.value = _this.instance.html.get();
+				});
 			});
-			this.instance.addEventListener('blur', function (e, editor) {
-				return _this.value = editor.html.get();
-			});
-
-			this.instance = new _froala_editorPkgdMin2.default('#' + this.element.id, Object.assign({}, this.config));
 		};
 
 		FroalaEditor1.prototype.tearDown = function tearDown() {

--- a/dist/amd/froala-editor.js
+++ b/dist/amd/froala-editor.js
@@ -107,13 +107,17 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 				if (_this.eventHandlers && _this.eventHandlers.length != 0) {
 					var _loop = function _loop(eventHandlerName) {
 						var handler = _this.eventHandlers[eventHandlerName];
-						_this.editor.events.on('' + eventHandlerName, function () {
-							for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
-								args[_key] = arguments[_key];
-							}
+						if (eventHandlerName === 'initialized') {
+							handler.apply(_this.parent);
+						} else {
+							_this.editor.events.on('' + eventHandlerName, function () {
+								for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+									args[_key] = arguments[_key];
+								}
 
-							return handler.apply(_this.parent, args);
-						});
+								return handler.apply(_this.parent, args);
+							});
+						}
 					};
 
 					for (var eventHandlerName in _this.eventHandlers) {

--- a/dist/amd/froala-editor.js
+++ b/dist/amd/froala-editor.js
@@ -101,7 +101,7 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 				}
 			})];
 
-			this.editor = new _froala_editorPkgdMin2.default('#' + this.element.id + ' ' + editorSelector, Object.assign({}, this.config), function () {
+			this.editor = new _froala_editorPkgdMin2.default(this.element.querySelector(editorSelector), Object.assign({}, this.config), function () {
 				_this.editor.html.set(_this.value);
 
 				if (_this.eventHandlers && _this.eventHandlers.length != 0) {

--- a/dist/amd/froala-editor.js
+++ b/dist/amd/froala-editor.js
@@ -101,8 +101,6 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 				return;
 			}
 
-			this.instance.innerHTML = this.value;
-
 			this.subscriptions = [this.observerLocator.getObserver(this, 'value').subscribe(function (newValue, oldValue) {
 				if (_this.instance && _this.instance.html.get() != newValue) {
 					_this.instance.html.set(newValue);
@@ -110,6 +108,8 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 			})];
 
 			this.instance = new _froala_editorPkgdMin2.default('#' + this.element.id + ' div', Object.assign({}, this.config), function () {
+				_this.instance.html.set(_this.value);
+
 				if (_this.eventHandlers && _this.eventHandlers.length != 0) {
 					var _loop = function _loop(eventHandlerName) {
 						var handler = _this.eventHandlers[eventHandlerName];

--- a/dist/amd/froala-editor.js
+++ b/dist/amd/froala-editor.js
@@ -78,9 +78,7 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 			_initDefineProp(this, 'instance', _descriptor4, this);
 
 			this.element = element;
-
 			this.config = config.options();
-
 			this.observerLocator = observerLocator;
 		}
 
@@ -88,7 +86,7 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 			this.parent = bindingContext;
 		};
 
-		FroalaEditor1.prototype.tearUp = function tearUp() {
+		FroalaEditor1.prototype.attached = function attached() {
 			var _this = this;
 
 			var editorSelector = this.config.iframe ? 'textarea' : 'div';
@@ -131,19 +129,11 @@ define(['exports', 'aurelia-framework', 'aurelia-binding', './froala-editor-conf
 			});
 		};
 
-		FroalaEditor1.prototype.tearDown = function tearDown() {
+		FroalaEditor1.prototype.detached = function detached() {
 			if (this.instance != null) {
 				this.instance.destroy();
 				this.instance = null;
 			}
-		};
-
-		FroalaEditor1.prototype.attached = function attached() {
-			this.tearUp();
-		};
-
-		FroalaEditor1.prototype.detached = function detached() {
-			this.tearDown();
 		};
 
 		return FroalaEditor1;

--- a/dist/commonjs/froala-editor.js
+++ b/dist/commonjs/froala-editor.js
@@ -90,11 +90,8 @@ var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.custom
 	FroalaEditor1.prototype.tearUp = function tearUp() {
 		var _this = this;
 
-		if (this.config.iframe) {
-			this.instance = this.element.getElementsByTagName('textarea')[0];
-		} else {
-			this.instance = this.element.getElementsByTagName('div')[0];
-		}
+		var editorSelector = this.config.iframe ? 'textarea' : 'div';
+		this.instance = this.element.querySelector(editorSelector);
 
 		if (this.instance['data-froala.editor']) {
 			return;
@@ -106,7 +103,7 @@ var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.custom
 			}
 		})];
 
-		this.instance = new _froala_editorPkgdMin2.default('#' + this.element.id + ' div', Object.assign({}, this.config), function () {
+		this.instance = new _froala_editorPkgdMin2.default('#' + this.element.id + ' ' + editorSelector, Object.assign({}, this.config), function () {
 			_this.instance.html.set(_this.value);
 
 			if (_this.eventHandlers && _this.eventHandlers.length != 0) {

--- a/dist/commonjs/froala-editor.js
+++ b/dist/commonjs/froala-editor.js
@@ -100,8 +100,6 @@ var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.custom
 			return;
 		}
 
-		this.instance.innerHTML = this.value;
-
 		this.subscriptions = [this.observerLocator.getObserver(this, 'value').subscribe(function (newValue, oldValue) {
 			if (_this.instance && _this.instance.html.get() != newValue) {
 				_this.instance.html.set(newValue);
@@ -109,6 +107,8 @@ var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.custom
 		})];
 
 		this.instance = new _froala_editorPkgdMin2.default('#' + this.element.id + ' div', Object.assign({}, this.config), function () {
+			_this.instance.html.set(_this.value);
+
 			if (_this.eventHandlers && _this.eventHandlers.length != 0) {
 				var _loop = function _loop(eventHandlerName) {
 					var handler = _this.eventHandlers[eventHandlerName];

--- a/dist/commonjs/froala-editor.js
+++ b/dist/commonjs/froala-editor.js
@@ -5,7 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.FroalaEditor1 = undefined;
 
-var _dec, _dec2, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3;
+var _dec, _dec2, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4;
 
 var _aureliaFramework = require('aurelia-framework');
 
@@ -73,6 +73,8 @@ var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.custom
 		_initDefineProp(this, 'config', _descriptor2, this);
 
 		_initDefineProp(this, 'eventHandlers', _descriptor3, this);
+
+		_initDefineProp(this, 'instance', _descriptor4, this);
 
 		this.element = element;
 
@@ -155,4 +157,7 @@ var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.custom
 	initializer: function initializer() {
 		return {};
 	}
+}), _descriptor4 = _applyDecoratedDescriptor(_class2.prototype, 'instance', [_aureliaFramework.bindable], {
+	enumerable: true,
+	initializer: null
 })), _class2)) || _class) || _class);

--- a/dist/commonjs/froala-editor.js
+++ b/dist/commonjs/froala-editor.js
@@ -77,9 +77,7 @@ var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.custom
 		_initDefineProp(this, 'instance', _descriptor4, this);
 
 		this.element = element;
-
 		this.config = config.options();
-
 		this.observerLocator = observerLocator;
 	}
 
@@ -87,7 +85,7 @@ var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.custom
 		this.parent = bindingContext;
 	};
 
-	FroalaEditor1.prototype.tearUp = function tearUp() {
+	FroalaEditor1.prototype.attached = function attached() {
 		var _this = this;
 
 		var editorSelector = this.config.iframe ? 'textarea' : 'div';
@@ -130,19 +128,11 @@ var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.custom
 		});
 	};
 
-	FroalaEditor1.prototype.tearDown = function tearDown() {
+	FroalaEditor1.prototype.detached = function detached() {
 		if (this.instance != null) {
 			this.instance.destroy();
 			this.instance = null;
 		}
-	};
-
-	FroalaEditor1.prototype.attached = function attached() {
-		this.tearUp();
-	};
-
-	FroalaEditor1.prototype.detached = function detached() {
-		this.tearDown();
 	};
 
 	return FroalaEditor1;

--- a/dist/commonjs/froala-editor.js
+++ b/dist/commonjs/froala-editor.js
@@ -106,13 +106,17 @@ var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.custom
 			if (_this.eventHandlers && _this.eventHandlers.length != 0) {
 				var _loop = function _loop(eventHandlerName) {
 					var handler = _this.eventHandlers[eventHandlerName];
-					_this.editor.events.on('' + eventHandlerName, function () {
-						for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
-							args[_key] = arguments[_key];
-						}
+					if (eventHandlerName === 'initialized') {
+						handler.apply(_this.parent);
+					} else {
+						_this.editor.events.on('' + eventHandlerName, function () {
+							for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+								args[_key] = arguments[_key];
+							}
 
-						return handler.apply(_this.parent, args);
-					});
+							return handler.apply(_this.parent, args);
+						});
+					}
 				};
 
 				for (var eventHandlerName in _this.eventHandlers) {

--- a/dist/commonjs/froala-editor.js
+++ b/dist/commonjs/froala-editor.js
@@ -100,7 +100,7 @@ var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.custom
 			}
 		})];
 
-		this.editor = new _froala_editorPkgdMin2.default('#' + this.element.id + ' ' + editorSelector, Object.assign({}, this.config), function () {
+		this.editor = new _froala_editorPkgdMin2.default(this.element.querySelector(editorSelector), Object.assign({}, this.config), function () {
 			_this.editor.html.set(_this.value);
 
 			if (_this.eventHandlers && _this.eventHandlers.length != 0) {

--- a/dist/commonjs/froala-editor.js
+++ b/dist/commonjs/froala-editor.js
@@ -91,9 +91,8 @@ var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.custom
 		var _this = this;
 
 		var editorSelector = this.config.iframe ? 'textarea' : 'div';
-		this.instance = this.element.querySelector(editorSelector);
 
-		if (this.instance['data-froala.editor']) {
+		if (this.instance != null) {
 			return;
 		}
 
@@ -132,11 +131,10 @@ var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.custom
 	};
 
 	FroalaEditor1.prototype.tearDown = function tearDown() {
-		if (this.instance && this.instance['data-froala.editor']) {
+		if (this.instance != null) {
 			this.instance.destroy();
+			this.instance = null;
 		}
-
-		this.instance = null;
 	};
 
 	FroalaEditor1.prototype.attached = function attached() {

--- a/dist/commonjs/froala-editor.js
+++ b/dist/commonjs/froala-editor.js
@@ -66,8 +66,6 @@ function _initializerWarningHelper(descriptor, context) {
 
 var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.customElement)('froala-editor'), _dec2 = (0, _aureliaFramework.inject)(Element, _froalaEditorConfig.Config, _aureliaBinding.ObserverLocator), _dec(_class = _dec2(_class = (_class2 = function () {
 	function FroalaEditor1(element, config, observerLocator) {
-		var _this = this;
-
 		_classCallCheck(this, FroalaEditor1);
 
 		_initDefineProp(this, 'value', _descriptor, this);
@@ -80,15 +78,11 @@ var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.custom
 
 		this.config = config.options();
 
-		this.subscriptions = [observerLocator.getObserver(this, 'value').subscribe(function (newValue, oldValue) {
-			if (_this.instance && _this.instance.html.get() != newValue) {
-				_this.instance.html(newValue);
-			}
-		})];
+		this.observerLocator = observerLocator;
 	}
 
 	FroalaEditor1.prototype.tearUp = function tearUp() {
-		var _this2 = this;
+		var _this = this;
 
 		if (this.config.iframe) {
 			this.instance = this.element.getElementsByTagName('textarea')[0];
@@ -102,10 +96,16 @@ var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.custom
 
 		this.instance.innerHTML = this.value;
 
+		this.subscriptions = [this.observerLocator.getObserver(this, 'value').subscribe(function (newValue, oldValue) {
+			if (_this.instance && _this.instance.html.get() != newValue) {
+				_this.instance.html.set(newValue);
+			}
+		})];
+
 		if (this.eventHandlers && this.eventHandlers.length != 0) {
 			var _loop = function _loop(eventHandlerName) {
-				var handler = _this2.eventHandlers[eventHandlerName];
-				_this2.instance.addEventListener('' + eventHandlerName, function () {
+				var handler = _this.eventHandlers[eventHandlerName];
+				_this.instance.addEventListener('' + eventHandlerName, function () {
 					var p = arguments;
 					return handler.apply(this, p);
 				});
@@ -116,10 +116,10 @@ var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.custom
 			}
 		}
 		this.instance.addEventListener('contentChanged', function (e, editor) {
-			return _this2.value = editor.html.get();
+			return _this.value = editor.html.get();
 		});
 		this.instance.addEventListener('blur', function (e, editor) {
-			return _this2.value = editor.html.get();
+			return _this.value = editor.html.get();
 		});
 
 		this.instance = new _froala_editorPkgdMin2.default('#' + this.element.id, Object.assign({}, this.config));

--- a/dist/commonjs/froala-editor.js
+++ b/dist/commonjs/froala-editor.js
@@ -74,7 +74,7 @@ var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.custom
 
 		_initDefineProp(this, 'eventHandlers', _descriptor3, this);
 
-		_initDefineProp(this, 'instance', _descriptor4, this);
+		_initDefineProp(this, 'editor', _descriptor4, this);
 
 		this.element = element;
 		this.config = config.options();
@@ -90,23 +90,23 @@ var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.custom
 
 		var editorSelector = this.config.iframe ? 'textarea' : 'div';
 
-		if (this.instance != null) {
+		if (this.editor != null) {
 			return;
 		}
 
 		this.subscriptions = [this.observerLocator.getObserver(this, 'value').subscribe(function (newValue, oldValue) {
-			if (_this.instance && _this.instance.html.get() != newValue) {
-				_this.instance.html.set(newValue);
+			if (_this.editor && _this.editor.html.get() != newValue) {
+				_this.editor.html.set(newValue);
 			}
 		})];
 
-		this.instance = new _froala_editorPkgdMin2.default('#' + this.element.id + ' ' + editorSelector, Object.assign({}, this.config), function () {
-			_this.instance.html.set(_this.value);
+		this.editor = new _froala_editorPkgdMin2.default('#' + this.element.id + ' ' + editorSelector, Object.assign({}, this.config), function () {
+			_this.editor.html.set(_this.value);
 
 			if (_this.eventHandlers && _this.eventHandlers.length != 0) {
 				var _loop = function _loop(eventHandlerName) {
 					var handler = _this.eventHandlers[eventHandlerName];
-					_this.instance.events.on('' + eventHandlerName, function () {
+					_this.editor.events.on('' + eventHandlerName, function () {
 						for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
 							args[_key] = arguments[_key];
 						}
@@ -119,19 +119,19 @@ var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.custom
 					_loop(eventHandlerName);
 				}
 			}
-			_this.instance.events.on('blur', function (e) {
-				return _this.value = _this.instance.html.get();
+			_this.editor.events.on('blur', function (e) {
+				return _this.value = _this.editor.html.get();
 			});
-			_this.instance.events.on('contentChanged', function (e) {
-				return _this.value = _this.instance.html.get();
+			_this.editor.events.on('contentChanged', function (e) {
+				return _this.value = _this.editor.html.get();
 			});
 		});
 	};
 
 	FroalaEditor1.prototype.detached = function detached() {
-		if (this.instance != null) {
-			this.instance.destroy();
-			this.instance = null;
+		if (this.editor != null) {
+			this.editor.destroy();
+			this.editor = null;
 		}
 	};
 
@@ -149,7 +149,7 @@ var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.custom
 	initializer: function initializer() {
 		return {};
 	}
-}), _descriptor4 = _applyDecoratedDescriptor(_class2.prototype, 'instance', [_aureliaFramework.bindable], {
+}), _descriptor4 = _applyDecoratedDescriptor(_class2.prototype, 'editor', [_aureliaFramework.bindable], {
 	enumerable: true,
 	initializer: null
 })), _class2)) || _class) || _class);

--- a/dist/commonjs/froala-editor.js
+++ b/dist/commonjs/froala-editor.js
@@ -83,6 +83,10 @@ var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.custom
 		this.observerLocator = observerLocator;
 	}
 
+	FroalaEditor1.prototype.bind = function bind(bindingContext, overrideContext) {
+		this.parent = bindingContext;
+	};
+
 	FroalaEditor1.prototype.tearUp = function tearUp() {
 		var _this = this;
 
@@ -104,27 +108,30 @@ var FroalaEditor1 = exports.FroalaEditor1 = (_dec = (0, _aureliaFramework.custom
 			}
 		})];
 
-		if (this.eventHandlers && this.eventHandlers.length != 0) {
-			var _loop = function _loop(eventHandlerName) {
-				var handler = _this.eventHandlers[eventHandlerName];
-				_this.instance.addEventListener('' + eventHandlerName, function () {
-					var p = arguments;
-					return handler.apply(this, p);
-				});
-			};
+		this.instance = new _froala_editorPkgdMin2.default('#' + this.element.id + ' div', Object.assign({}, this.config), function () {
+			if (_this.eventHandlers && _this.eventHandlers.length != 0) {
+				var _loop = function _loop(eventHandlerName) {
+					var handler = _this.eventHandlers[eventHandlerName];
+					_this.instance.events.on('' + eventHandlerName, function () {
+						for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+							args[_key] = arguments[_key];
+						}
 
-			for (var eventHandlerName in this.eventHandlers) {
-				_loop(eventHandlerName);
+						return handler.apply(_this.parent, args);
+					});
+				};
+
+				for (var eventHandlerName in _this.eventHandlers) {
+					_loop(eventHandlerName);
+				}
 			}
-		}
-		this.instance.addEventListener('contentChanged', function (e, editor) {
-			return _this.value = editor.html.get();
+			_this.instance.events.on('blur', function (e) {
+				return _this.value = _this.instance.html.get();
+			});
+			_this.instance.events.on('contentChanged', function (e) {
+				return _this.value = _this.instance.html.get();
+			});
 		});
-		this.instance.addEventListener('blur', function (e, editor) {
-			return _this.value = editor.html.get();
-		});
-
-		this.instance = new _froala_editorPkgdMin2.default('#' + this.element.id, Object.assign({}, this.config));
 	};
 
 	FroalaEditor1.prototype.tearDown = function tearDown() {

--- a/dist/es2015/froala-editor.js
+++ b/dist/es2015/froala-editor.js
@@ -68,6 +68,10 @@ export let FroalaEditor1 = (_dec = customElement('froala-editor'), _dec2 = injec
 		this.observerLocator = observerLocator;
 	}
 
+	bind(bindingContext, overrideContext) {
+		this.parent = bindingContext;
+	}
+
 	tearUp() {
 		if (this.config.iframe) {
 			this.instance = this.element.getElementsByTagName('textarea')[0];
@@ -87,19 +91,18 @@ export let FroalaEditor1 = (_dec = customElement('froala-editor'), _dec2 = injec
 			}
 		})];
 
-		if (this.eventHandlers && this.eventHandlers.length != 0) {
-			for (let eventHandlerName in this.eventHandlers) {
-				let handler = this.eventHandlers[eventHandlerName];
-				this.instance.addEventListener(`${eventHandlerName}`, function () {
-					let p = arguments;
-					return handler.apply(this, p);
-				});
+		this.instance = new FroalaEditor(`#${this.element.id} div`, Object.assign({}, this.config), () => {
+			if (this.eventHandlers && this.eventHandlers.length != 0) {
+				for (let eventHandlerName in this.eventHandlers) {
+					let handler = this.eventHandlers[eventHandlerName];
+					this.instance.events.on(`${eventHandlerName}`, (...args) => {
+						return handler.apply(this.parent, args);
+					});
+				}
 			}
-		}
-		this.instance.addEventListener('contentChanged', (e, editor) => this.value = editor.html.get());
-		this.instance.addEventListener('blur', (e, editor) => this.value = editor.html.get());
-
-		this.instance = new FroalaEditor(`#${this.element.id}`, Object.assign({}, this.config));
+			this.instance.events.on('blur', e => this.value = this.instance.html.get());
+			this.instance.events.on('contentChanged', e => this.value = this.instance.html.get());
+		});
 	}
 
 	tearDown() {

--- a/dist/es2015/froala-editor.js
+++ b/dist/es2015/froala-editor.js
@@ -62,9 +62,7 @@ export let FroalaEditor1 = (_dec = customElement('froala-editor'), _dec2 = injec
 		_initDefineProp(this, 'instance', _descriptor4, this);
 
 		this.element = element;
-
 		this.config = config.options();
-
 		this.observerLocator = observerLocator;
 	}
 
@@ -72,7 +70,7 @@ export let FroalaEditor1 = (_dec = customElement('froala-editor'), _dec2 = injec
 		this.parent = bindingContext;
 	}
 
-	tearUp() {
+	attached() {
 		const editorSelector = this.config.iframe ? 'textarea' : 'div';
 
 		if (this.instance != null) {
@@ -101,19 +99,11 @@ export let FroalaEditor1 = (_dec = customElement('froala-editor'), _dec2 = injec
 		});
 	}
 
-	tearDown() {
+	detached() {
 		if (this.instance != null) {
 			this.instance.destroy();
 			this.instance = null;
 		}
-	}
-
-	attached() {
-		this.tearUp();
-	}
-
-	detached() {
-		this.tearDown();
 	}
 }, (_descriptor = _applyDecoratedDescriptor(_class2.prototype, 'value', [bindable], {
 	enumerable: true,

--- a/dist/es2015/froala-editor.js
+++ b/dist/es2015/froala-editor.js
@@ -83,8 +83,6 @@ export let FroalaEditor1 = (_dec = customElement('froala-editor'), _dec2 = injec
 			return;
 		}
 
-		this.instance.innerHTML = this.value;
-
 		this.subscriptions = [this.observerLocator.getObserver(this, 'value').subscribe((newValue, oldValue) => {
 			if (this.instance && this.instance.html.get() != newValue) {
 				this.instance.html.set(newValue);
@@ -92,6 +90,8 @@ export let FroalaEditor1 = (_dec = customElement('froala-editor'), _dec2 = injec
 		})];
 
 		this.instance = new FroalaEditor(`#${this.element.id} div`, Object.assign({}, this.config), () => {
+			this.instance.html.set(this.value);
+
 			if (this.eventHandlers && this.eventHandlers.length != 0) {
 				for (let eventHandlerName in this.eventHandlers) {
 					let handler = this.eventHandlers[eventHandlerName];

--- a/dist/es2015/froala-editor.js
+++ b/dist/es2015/froala-editor.js
@@ -83,7 +83,7 @@ export let FroalaEditor1 = (_dec = customElement('froala-editor'), _dec2 = injec
 			}
 		})];
 
-		this.editor = new FroalaEditor(`#${this.element.id} ${editorSelector}`, Object.assign({}, this.config), () => {
+		this.editor = new FroalaEditor(this.element.querySelector(editorSelector), Object.assign({}, this.config), () => {
 			this.editor.html.set(this.value);
 
 			if (this.eventHandlers && this.eventHandlers.length != 0) {

--- a/dist/es2015/froala-editor.js
+++ b/dist/es2015/froala-editor.js
@@ -59,7 +59,7 @@ export let FroalaEditor1 = (_dec = customElement('froala-editor'), _dec2 = injec
 
 		_initDefineProp(this, 'eventHandlers', _descriptor3, this);
 
-		_initDefineProp(this, 'instance', _descriptor4, this);
+		_initDefineProp(this, 'editor', _descriptor4, this);
 
 		this.element = element;
 		this.config = config.options();
@@ -73,36 +73,36 @@ export let FroalaEditor1 = (_dec = customElement('froala-editor'), _dec2 = injec
 	attached() {
 		const editorSelector = this.config.iframe ? 'textarea' : 'div';
 
-		if (this.instance != null) {
+		if (this.editor != null) {
 			return;
 		}
 
 		this.subscriptions = [this.observerLocator.getObserver(this, 'value').subscribe((newValue, oldValue) => {
-			if (this.instance && this.instance.html.get() != newValue) {
-				this.instance.html.set(newValue);
+			if (this.editor && this.editor.html.get() != newValue) {
+				this.editor.html.set(newValue);
 			}
 		})];
 
-		this.instance = new FroalaEditor(`#${this.element.id} ${editorSelector}`, Object.assign({}, this.config), () => {
-			this.instance.html.set(this.value);
+		this.editor = new FroalaEditor(`#${this.element.id} ${editorSelector}`, Object.assign({}, this.config), () => {
+			this.editor.html.set(this.value);
 
 			if (this.eventHandlers && this.eventHandlers.length != 0) {
 				for (let eventHandlerName in this.eventHandlers) {
 					let handler = this.eventHandlers[eventHandlerName];
-					this.instance.events.on(`${eventHandlerName}`, (...args) => {
+					this.editor.events.on(`${eventHandlerName}`, (...args) => {
 						return handler.apply(this.parent, args);
 					});
 				}
 			}
-			this.instance.events.on('blur', e => this.value = this.instance.html.get());
-			this.instance.events.on('contentChanged', e => this.value = this.instance.html.get());
+			this.editor.events.on('blur', e => this.value = this.editor.html.get());
+			this.editor.events.on('contentChanged', e => this.value = this.editor.html.get());
 		});
 	}
 
 	detached() {
-		if (this.instance != null) {
-			this.instance.destroy();
-			this.instance = null;
+		if (this.editor != null) {
+			this.editor.destroy();
+			this.editor = null;
 		}
 	}
 }, (_descriptor = _applyDecoratedDescriptor(_class2.prototype, 'value', [bindable], {
@@ -118,7 +118,7 @@ export let FroalaEditor1 = (_dec = customElement('froala-editor'), _dec2 = injec
 	initializer: function () {
 		return {};
 	}
-}), _descriptor4 = _applyDecoratedDescriptor(_class2.prototype, 'instance', [bindable], {
+}), _descriptor4 = _applyDecoratedDescriptor(_class2.prototype, 'editor', [bindable], {
 	enumerable: true,
 	initializer: null
 })), _class2)) || _class) || _class);

--- a/dist/es2015/froala-editor.js
+++ b/dist/es2015/froala-editor.js
@@ -63,11 +63,7 @@ export let FroalaEditor1 = (_dec = customElement('froala-editor'), _dec2 = injec
 
 		this.config = config.options();
 
-		this.subscriptions = [observerLocator.getObserver(this, 'value').subscribe((newValue, oldValue) => {
-			if (this.instance && this.instance.html.get() != newValue) {
-				this.instance.html(newValue);
-			}
-		})];
+		this.observerLocator = observerLocator;
 	}
 
 	tearUp() {
@@ -82,6 +78,12 @@ export let FroalaEditor1 = (_dec = customElement('froala-editor'), _dec2 = injec
 		}
 
 		this.instance.innerHTML = this.value;
+
+		this.subscriptions = [this.observerLocator.getObserver(this, 'value').subscribe((newValue, oldValue) => {
+			if (this.instance && this.instance.html.get() != newValue) {
+				this.instance.html.set(newValue);
+			}
+		})];
 
 		if (this.eventHandlers && this.eventHandlers.length != 0) {
 			for (let eventHandlerName in this.eventHandlers) {

--- a/dist/es2015/froala-editor.js
+++ b/dist/es2015/froala-editor.js
@@ -89,9 +89,13 @@ export let FroalaEditor1 = (_dec = customElement('froala-editor'), _dec2 = injec
 			if (this.eventHandlers && this.eventHandlers.length != 0) {
 				for (let eventHandlerName in this.eventHandlers) {
 					let handler = this.eventHandlers[eventHandlerName];
-					this.editor.events.on(`${eventHandlerName}`, (...args) => {
-						return handler.apply(this.parent, args);
-					});
+					if (eventHandlerName === 'initialized') {
+						handler.apply(this.parent);
+					} else {
+						this.editor.events.on(`${eventHandlerName}`, (...args) => {
+							return handler.apply(this.parent, args);
+						});
+					}
 				}
 			}
 			this.editor.events.on('blur', e => this.value = this.editor.html.get());

--- a/dist/es2015/froala-editor.js
+++ b/dist/es2015/froala-editor.js
@@ -74,9 +74,8 @@ export let FroalaEditor1 = (_dec = customElement('froala-editor'), _dec2 = injec
 
 	tearUp() {
 		const editorSelector = this.config.iframe ? 'textarea' : 'div';
-		this.instance = this.element.querySelector(editorSelector);
 
-		if (this.instance['data-froala.editor']) {
+		if (this.instance != null) {
 			return;
 		}
 
@@ -103,11 +102,10 @@ export let FroalaEditor1 = (_dec = customElement('froala-editor'), _dec2 = injec
 	}
 
 	tearDown() {
-		if (this.instance && this.instance['data-froala.editor']) {
+		if (this.instance != null) {
 			this.instance.destroy();
+			this.instance = null;
 		}
-
-		this.instance = null;
 	}
 
 	attached() {

--- a/dist/es2015/froala-editor.js
+++ b/dist/es2015/froala-editor.js
@@ -73,11 +73,8 @@ export let FroalaEditor1 = (_dec = customElement('froala-editor'), _dec2 = injec
 	}
 
 	tearUp() {
-		if (this.config.iframe) {
-			this.instance = this.element.getElementsByTagName('textarea')[0];
-		} else {
-			this.instance = this.element.getElementsByTagName('div')[0];
-		}
+		const editorSelector = this.config.iframe ? 'textarea' : 'div';
+		this.instance = this.element.querySelector(editorSelector);
 
 		if (this.instance['data-froala.editor']) {
 			return;
@@ -89,7 +86,7 @@ export let FroalaEditor1 = (_dec = customElement('froala-editor'), _dec2 = injec
 			}
 		})];
 
-		this.instance = new FroalaEditor(`#${this.element.id} div`, Object.assign({}, this.config), () => {
+		this.instance = new FroalaEditor(`#${this.element.id} ${editorSelector}`, Object.assign({}, this.config), () => {
 			this.instance.html.set(this.value);
 
 			if (this.eventHandlers && this.eventHandlers.length != 0) {

--- a/dist/es2015/froala-editor.js
+++ b/dist/es2015/froala-editor.js
@@ -1,4 +1,4 @@
-var _dec, _dec2, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3;
+var _dec, _dec2, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4;
 
 function _initDefineProp(target, property, descriptor, context) {
 	if (!descriptor) return;
@@ -58,6 +58,8 @@ export let FroalaEditor1 = (_dec = customElement('froala-editor'), _dec2 = injec
 		_initDefineProp(this, 'config', _descriptor2, this);
 
 		_initDefineProp(this, 'eventHandlers', _descriptor3, this);
+
+		_initDefineProp(this, 'instance', _descriptor4, this);
 
 		this.element = element;
 
@@ -128,4 +130,7 @@ export let FroalaEditor1 = (_dec = customElement('froala-editor'), _dec2 = injec
 	initializer: function () {
 		return {};
 	}
+}), _descriptor4 = _applyDecoratedDescriptor(_class2.prototype, 'instance', [bindable], {
+	enumerable: true,
+	initializer: null
 })), _class2)) || _class) || _class);

--- a/dist/system/froala-editor.js
+++ b/dist/system/froala-editor.js
@@ -77,7 +77,7 @@ System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config
 
 					_initDefineProp(this, 'eventHandlers', _descriptor3, this);
 
-					_initDefineProp(this, 'instance', _descriptor4, this);
+					_initDefineProp(this, 'editor', _descriptor4, this);
 
 					this.element = element;
 					this.config = config.options();
@@ -93,23 +93,23 @@ System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config
 
 					var editorSelector = this.config.iframe ? 'textarea' : 'div';
 
-					if (this.instance != null) {
+					if (this.editor != null) {
 						return;
 					}
 
 					this.subscriptions = [this.observerLocator.getObserver(this, 'value').subscribe(function (newValue, oldValue) {
-						if (_this.instance && _this.instance.html.get() != newValue) {
-							_this.instance.html.set(newValue);
+						if (_this.editor && _this.editor.html.get() != newValue) {
+							_this.editor.html.set(newValue);
 						}
 					})];
 
-					this.instance = new FroalaEditor('#' + this.element.id + ' ' + editorSelector, Object.assign({}, this.config), function () {
-						_this.instance.html.set(_this.value);
+					this.editor = new FroalaEditor('#' + this.element.id + ' ' + editorSelector, Object.assign({}, this.config), function () {
+						_this.editor.html.set(_this.value);
 
 						if (_this.eventHandlers && _this.eventHandlers.length != 0) {
 							var _loop = function _loop(eventHandlerName) {
 								var handler = _this.eventHandlers[eventHandlerName];
-								_this.instance.events.on('' + eventHandlerName, function () {
+								_this.editor.events.on('' + eventHandlerName, function () {
 									for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
 										args[_key] = arguments[_key];
 									}
@@ -122,19 +122,19 @@ System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config
 								_loop(eventHandlerName);
 							}
 						}
-						_this.instance.events.on('blur', function (e) {
-							return _this.value = _this.instance.html.get();
+						_this.editor.events.on('blur', function (e) {
+							return _this.value = _this.editor.html.get();
 						});
-						_this.instance.events.on('contentChanged', function (e) {
-							return _this.value = _this.instance.html.get();
+						_this.editor.events.on('contentChanged', function (e) {
+							return _this.value = _this.editor.html.get();
 						});
 					});
 				};
 
 				FroalaEditor1.prototype.detached = function detached() {
-					if (this.instance != null) {
-						this.instance.destroy();
-						this.instance = null;
+					if (this.editor != null) {
+						this.editor.destroy();
+						this.editor = null;
 					}
 				};
 
@@ -152,7 +152,7 @@ System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config
 				initializer: function initializer() {
 					return {};
 				}
-			}), _descriptor4 = _applyDecoratedDescriptor(_class2.prototype, 'instance', [bindable], {
+			}), _descriptor4 = _applyDecoratedDescriptor(_class2.prototype, 'editor', [bindable], {
 				enumerable: true,
 				initializer: null
 			})), _class2)) || _class) || _class));

--- a/dist/system/froala-editor.js
+++ b/dist/system/froala-editor.js
@@ -109,13 +109,17 @@ System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config
 						if (_this.eventHandlers && _this.eventHandlers.length != 0) {
 							var _loop = function _loop(eventHandlerName) {
 								var handler = _this.eventHandlers[eventHandlerName];
-								_this.editor.events.on('' + eventHandlerName, function () {
-									for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
-										args[_key] = arguments[_key];
-									}
+								if (eventHandlerName === 'initialized') {
+									handler.apply(_this.parent);
+								} else {
+									_this.editor.events.on('' + eventHandlerName, function () {
+										for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+											args[_key] = arguments[_key];
+										}
 
-									return handler.apply(_this.parent, args);
-								});
+										return handler.apply(_this.parent, args);
+									});
+								}
 							};
 
 							for (var eventHandlerName in _this.eventHandlers) {

--- a/dist/system/froala-editor.js
+++ b/dist/system/froala-editor.js
@@ -93,11 +93,8 @@ System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config
 				FroalaEditor1.prototype.tearUp = function tearUp() {
 					var _this = this;
 
-					if (this.config.iframe) {
-						this.instance = this.element.getElementsByTagName('textarea')[0];
-					} else {
-						this.instance = this.element.getElementsByTagName('div')[0];
-					}
+					var editorSelector = this.config.iframe ? 'textarea' : 'div';
+					this.instance = this.element.querySelector(editorSelector);
 
 					if (this.instance['data-froala.editor']) {
 						return;
@@ -109,7 +106,7 @@ System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config
 						}
 					})];
 
-					this.instance = new FroalaEditor('#' + this.element.id + ' div', Object.assign({}, this.config), function () {
+					this.instance = new FroalaEditor('#' + this.element.id + ' ' + editorSelector, Object.assign({}, this.config), function () {
 						_this.instance.html.set(_this.value);
 
 						if (_this.eventHandlers && _this.eventHandlers.length != 0) {

--- a/dist/system/froala-editor.js
+++ b/dist/system/froala-editor.js
@@ -80,9 +80,7 @@ System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config
 					_initDefineProp(this, 'instance', _descriptor4, this);
 
 					this.element = element;
-
 					this.config = config.options();
-
 					this.observerLocator = observerLocator;
 				}
 
@@ -90,7 +88,7 @@ System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config
 					this.parent = bindingContext;
 				};
 
-				FroalaEditor1.prototype.tearUp = function tearUp() {
+				FroalaEditor1.prototype.attached = function attached() {
 					var _this = this;
 
 					var editorSelector = this.config.iframe ? 'textarea' : 'div';
@@ -133,19 +131,11 @@ System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config
 					});
 				};
 
-				FroalaEditor1.prototype.tearDown = function tearDown() {
+				FroalaEditor1.prototype.detached = function detached() {
 					if (this.instance != null) {
 						this.instance.destroy();
 						this.instance = null;
 					}
-				};
-
-				FroalaEditor1.prototype.attached = function attached() {
-					this.tearUp();
-				};
-
-				FroalaEditor1.prototype.detached = function detached() {
-					this.tearDown();
 				};
 
 				return FroalaEditor1;

--- a/dist/system/froala-editor.js
+++ b/dist/system/froala-editor.js
@@ -86,6 +86,10 @@ System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config
 					this.observerLocator = observerLocator;
 				}
 
+				FroalaEditor1.prototype.bind = function bind(bindingContext, overrideContext) {
+					this.parent = bindingContext;
+				};
+
 				FroalaEditor1.prototype.tearUp = function tearUp() {
 					var _this = this;
 
@@ -107,27 +111,30 @@ System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config
 						}
 					})];
 
-					if (this.eventHandlers && this.eventHandlers.length != 0) {
-						var _loop = function _loop(eventHandlerName) {
-							var handler = _this.eventHandlers[eventHandlerName];
-							_this.instance.addEventListener('' + eventHandlerName, function () {
-								var p = arguments;
-								return handler.apply(this, p);
-							});
-						};
+					this.instance = new FroalaEditor('#' + this.element.id + ' div', Object.assign({}, this.config), function () {
+						if (_this.eventHandlers && _this.eventHandlers.length != 0) {
+							var _loop = function _loop(eventHandlerName) {
+								var handler = _this.eventHandlers[eventHandlerName];
+								_this.instance.events.on('' + eventHandlerName, function () {
+									for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+										args[_key] = arguments[_key];
+									}
 
-						for (var eventHandlerName in this.eventHandlers) {
-							_loop(eventHandlerName);
+									return handler.apply(_this.parent, args);
+								});
+							};
+
+							for (var eventHandlerName in _this.eventHandlers) {
+								_loop(eventHandlerName);
+							}
 						}
-					}
-					this.instance.addEventListener('contentChanged', function (e, editor) {
-						return _this.value = editor.html.get();
+						_this.instance.events.on('blur', function (e) {
+							return _this.value = _this.instance.html.get();
+						});
+						_this.instance.events.on('contentChanged', function (e) {
+							return _this.value = _this.instance.html.get();
+						});
 					});
-					this.instance.addEventListener('blur', function (e, editor) {
-						return _this.value = editor.html.get();
-					});
-
-					this.instance = new FroalaEditor('#' + this.element.id, Object.assign({}, this.config));
 				};
 
 				FroalaEditor1.prototype.tearDown = function tearDown() {

--- a/dist/system/froala-editor.js
+++ b/dist/system/froala-editor.js
@@ -103,7 +103,7 @@ System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config
 						}
 					})];
 
-					this.editor = new FroalaEditor('#' + this.element.id + ' ' + editorSelector, Object.assign({}, this.config), function () {
+					this.editor = new FroalaEditor(this.element.querySelector(editorSelector), Object.assign({}, this.config), function () {
 						_this.editor.html.set(_this.value);
 
 						if (_this.eventHandlers && _this.eventHandlers.length != 0) {

--- a/dist/system/froala-editor.js
+++ b/dist/system/froala-editor.js
@@ -69,8 +69,6 @@ System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config
 		execute: function () {
 			_export('FroalaEditor1', FroalaEditor1 = (_dec = customElement('froala-editor'), _dec2 = inject(Element, Config, ObserverLocator), _dec(_class = _dec2(_class = (_class2 = function () {
 				function FroalaEditor1(element, config, observerLocator) {
-					var _this = this;
-
 					_classCallCheck(this, FroalaEditor1);
 
 					_initDefineProp(this, 'value', _descriptor, this);
@@ -83,15 +81,11 @@ System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config
 
 					this.config = config.options();
 
-					this.subscriptions = [observerLocator.getObserver(this, 'value').subscribe(function (newValue, oldValue) {
-						if (_this.instance && _this.instance.html.get() != newValue) {
-							_this.instance.html(newValue);
-						}
-					})];
+					this.observerLocator = observerLocator;
 				}
 
 				FroalaEditor1.prototype.tearUp = function tearUp() {
-					var _this2 = this;
+					var _this = this;
 
 					if (this.config.iframe) {
 						this.instance = this.element.getElementsByTagName('textarea')[0];
@@ -105,10 +99,16 @@ System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config
 
 					this.instance.innerHTML = this.value;
 
+					this.subscriptions = [this.observerLocator.getObserver(this, 'value').subscribe(function (newValue, oldValue) {
+						if (_this.instance && _this.instance.html.get() != newValue) {
+							_this.instance.html.set(newValue);
+						}
+					})];
+
 					if (this.eventHandlers && this.eventHandlers.length != 0) {
 						var _loop = function _loop(eventHandlerName) {
-							var handler = _this2.eventHandlers[eventHandlerName];
-							_this2.instance.addEventListener('' + eventHandlerName, function () {
+							var handler = _this.eventHandlers[eventHandlerName];
+							_this.instance.addEventListener('' + eventHandlerName, function () {
 								var p = arguments;
 								return handler.apply(this, p);
 							});
@@ -119,10 +119,10 @@ System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config
 						}
 					}
 					this.instance.addEventListener('contentChanged', function (e, editor) {
-						return _this2.value = editor.html.get();
+						return _this.value = editor.html.get();
 					});
 					this.instance.addEventListener('blur', function (e, editor) {
-						return _this2.value = editor.html.get();
+						return _this.value = editor.html.get();
 					});
 
 					this.instance = new FroalaEditor('#' + this.element.id, Object.assign({}, this.config));

--- a/dist/system/froala-editor.js
+++ b/dist/system/froala-editor.js
@@ -103,8 +103,6 @@ System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config
 						return;
 					}
 
-					this.instance.innerHTML = this.value;
-
 					this.subscriptions = [this.observerLocator.getObserver(this, 'value').subscribe(function (newValue, oldValue) {
 						if (_this.instance && _this.instance.html.get() != newValue) {
 							_this.instance.html.set(newValue);
@@ -112,6 +110,8 @@ System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config
 					})];
 
 					this.instance = new FroalaEditor('#' + this.element.id + ' div', Object.assign({}, this.config), function () {
+						_this.instance.html.set(_this.value);
+
 						if (_this.eventHandlers && _this.eventHandlers.length != 0) {
 							var _loop = function _loop(eventHandlerName) {
 								var handler = _this.eventHandlers[eventHandlerName];

--- a/dist/system/froala-editor.js
+++ b/dist/system/froala-editor.js
@@ -94,9 +94,8 @@ System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config
 					var _this = this;
 
 					var editorSelector = this.config.iframe ? 'textarea' : 'div';
-					this.instance = this.element.querySelector(editorSelector);
 
-					if (this.instance['data-froala.editor']) {
+					if (this.instance != null) {
 						return;
 					}
 
@@ -135,11 +134,10 @@ System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config
 				};
 
 				FroalaEditor1.prototype.tearDown = function tearDown() {
-					if (this.instance && this.instance['data-froala.editor']) {
+					if (this.instance != null) {
 						this.instance.destroy();
+						this.instance = null;
 					}
-
-					this.instance = null;
 				};
 
 				FroalaEditor1.prototype.attached = function attached() {

--- a/dist/system/froala-editor.js
+++ b/dist/system/froala-editor.js
@@ -3,7 +3,7 @@
 System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config', 'froala-editor/js/froala_editor.pkgd.min.js'], function (_export, _context) {
 	"use strict";
 
-	var inject, customElement, bindable, ObserverLocator, Config, FroalaEditor, _dec, _dec2, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, FroalaEditor1;
+	var inject, customElement, bindable, ObserverLocator, Config, FroalaEditor, _dec, _dec2, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4, FroalaEditor1;
 
 	function _initDefineProp(target, property, descriptor, context) {
 		if (!descriptor) return;
@@ -76,6 +76,8 @@ System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config
 					_initDefineProp(this, 'config', _descriptor2, this);
 
 					_initDefineProp(this, 'eventHandlers', _descriptor3, this);
+
+					_initDefineProp(this, 'instance', _descriptor4, this);
 
 					this.element = element;
 
@@ -158,6 +160,9 @@ System.register(['aurelia-framework', 'aurelia-binding', './froala-editor-config
 				initializer: function initializer() {
 					return {};
 				}
+			}), _descriptor4 = _applyDecoratedDescriptor(_class2.prototype, 'instance', [bindable], {
+				enumerable: true,
+				initializer: null
 			})), _class2)) || _class) || _class));
 
 			_export('FroalaEditor1', FroalaEditor1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-froala-editor",
-  "version": "3.0.3",
+  "version": "3.0.3-2",
   "description": "Aurelia plugin for Froala WYSIWYG HTML rich text editor.",
   "keywords": [
     "aurelia",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "babel-preset-stage-1": "^6.22.0",
     "conventional-changelog": "^2.0.3",
     "del": "^3.0.0",
-    "gulp": "^4.0.0",
+    "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-bump": "^2.7.0",
     "gulp-eslint": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-froala-editor",
-  "version": "3.0.3-2",
+  "version": "3.0.6",
   "description": "Aurelia plugin for Froala WYSIWYG HTML rich text editor.",
   "keywords": [
     "aurelia",
@@ -59,7 +59,7 @@
   "dependencies": {
     "aurelia-binding": "^2.1.4",
     "aurelia-framework": "^1.3.0",
-    "froala-editor": "3.0.3"
+    "froala-editor": "3.0.6"
   },
   "jspm": {
     "jspmNodeConversion": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-froala-editor",
-  "version": "3.0.1",
+  "version": "3.0.3",
   "description": "Aurelia plugin for Froala WYSIWYG HTML rich text editor.",
   "keywords": [
     "aurelia",
@@ -59,7 +59,7 @@
   "dependencies": {
     "aurelia-binding": "^2.1.4",
     "aurelia-framework": "^1.3.0",
-    "froala-editor": "3.0.1"
+    "froala-editor": "3.0.3"
   },
   "jspm": {
     "jspmNodeConversion": false,

--- a/src/froala-editor.js
+++ b/src/froala-editor.js
@@ -48,7 +48,7 @@ export class FroalaEditor1 {
 			];
 
 		// Initialize editor.
-		this.editor = new FroalaEditor(`#${this.element.id} ${editorSelector}`, Object.assign({}, this.config), () => {
+		this.editor = new FroalaEditor(this.element.querySelector(editorSelector), Object.assign({}, this.config), () => {
 			// Set initial HTML value.
 			this.editor.html.set(this.value);
 

--- a/src/froala-editor.js
+++ b/src/froala-editor.js
@@ -23,16 +23,7 @@ export class FroalaEditor1 {
     // Read config.
     this.config = config.options();
 
-    // Observe value.
-		this.subscriptions = [
-			observerLocator
-					.getObserver(this, 'value')
-					.subscribe((newValue, oldValue) => {
-						if (this.instance && this.instance.html.get() != newValue) {
-							this.instance.html(newValue);
-						}
-					})
-				];
+		this.observerLocator = observerLocator;
 	}
 
   // Starting poing.
@@ -52,6 +43,17 @@ export class FroalaEditor1 {
 
     // Set the HTML for the inner element.
     this.instance.innerHTML = this.value;
+
+ 		// Observe value.
+		this.subscriptions = [
+			this.observerLocator
+					.getObserver(this, 'value')
+					.subscribe((newValue, oldValue) => {
+						if (this.instance && this.instance.html.get() != newValue) {
+							this.instance.html.set(newValue);
+						}
+					})
+			];
 
     // Set events.
 		if (this.eventHandlers && this.eventHandlers.length != 0) {

--- a/src/froala-editor.js
+++ b/src/froala-editor.js
@@ -35,12 +35,9 @@ export class FroalaEditor1 {
 	tearUp () {
 		// Get element.
 		const editorSelector = this.config.iframe ? 'textarea' : 'div';
-		this.instance = this.element.querySelector(editorSelector);
 
 		// Check if editor isn't already initialized.
-		if (this.instance['data-froala.editor']) {
-		  return;
-		}
+		if (this.instance != null) { return; }
 
 		// Observe value.
 		this.subscriptions = [
@@ -74,11 +71,10 @@ export class FroalaEditor1 {
 
 	// Destroy.
 	tearDown () {
-		if (this.instance && this.instance['data-froala.editor']) {
+		if (this.instance != null) {
 			this.instance.destroy();
+			this.instance = null;
 		}
-
-		this.instance = null;
 	}
 
 	// Setup.

--- a/src/froala-editor.js
+++ b/src/froala-editor.js
@@ -56,9 +56,13 @@ export class FroalaEditor1 {
 			if (this.eventHandlers && this.eventHandlers.length != 0) {
 				for(let eventHandlerName in this.eventHandlers) {
 					let handler = this.eventHandlers[eventHandlerName];
-					this.editor.events.on(`${eventHandlerName}`, (...args) => {
-						return handler.apply(this.parent, args);
-					});
+					if (eventHandlerName === 'initialized') {
+						handler.apply(this.parent);
+					} else {
+						this.editor.events.on(`${eventHandlerName}`, (...args) => {
+							return handler.apply(this.parent, args);
+						});
+					}
 				}
 			}
 			this.editor.events.on('blur', (e) => this.value = this.editor.html.get());

--- a/src/froala-editor.js
+++ b/src/froala-editor.js
@@ -34,12 +34,8 @@ export class FroalaEditor1 {
 	// Starting point.
 	tearUp () {
 		// Get element.
-		if (this.config.iframe) {
-			this.instance = this.element.getElementsByTagName('textarea')[0];
-		}
-		else {
-			this.instance = this.element.getElementsByTagName('div')[0];
-		}
+		const editorSelector = this.config.iframe ? 'textarea' : 'div';
+		this.instance = this.element.querySelector(editorSelector);
 
 		// Check if editor isn't already initialized.
 		if (this.instance['data-froala.editor']) {
@@ -58,7 +54,7 @@ export class FroalaEditor1 {
 			];
 
 		// Initialize editor.
-		this.instance = new FroalaEditor(`#${this.element.id} div`, Object.assign({}, this.config), () => {
+		this.instance = new FroalaEditor(`#${this.element.id} ${editorSelector}`, Object.assign({}, this.config), () => {
 			// Set initial HTML value.
 			this.instance.html.set(this.value);
 

--- a/src/froala-editor.js
+++ b/src/froala-editor.js
@@ -12,7 +12,7 @@ export class FroalaEditor1 {
 	@bindable value;
 	@bindable config = {};
 	@bindable eventHandlers = {};
-	@bindable instance;
+	@bindable editor;
 
 	parent;
 	element;
@@ -34,43 +34,43 @@ export class FroalaEditor1 {
 		const editorSelector = this.config.iframe ? 'textarea' : 'div';
 
 		// Check if editor isn't already initialized.
-		if (this.instance != null) { return; }
+		if (this.editor != null) { return; }
 
 		// Observe value.
 		this.subscriptions = [
 			this.observerLocator
 					.getObserver(this, 'value')
 					.subscribe((newValue, oldValue) => {
-						if (this.instance && this.instance.html.get() != newValue) {
-							this.instance.html.set(newValue);
+						if (this.editor && this.editor.html.get() != newValue) {
+							this.editor.html.set(newValue);
 						}
 					})
 			];
 
 		// Initialize editor.
-		this.instance = new FroalaEditor(`#${this.element.id} ${editorSelector}`, Object.assign({}, this.config), () => {
+		this.editor = new FroalaEditor(`#${this.element.id} ${editorSelector}`, Object.assign({}, this.config), () => {
 			// Set initial HTML value.
-			this.instance.html.set(this.value);
+			this.editor.html.set(this.value);
 
 			// Set Events
 			if (this.eventHandlers && this.eventHandlers.length != 0) {
 				for(let eventHandlerName in this.eventHandlers) {
 					let handler = this.eventHandlers[eventHandlerName];
-					this.instance.events.on(`${eventHandlerName}`, (...args) => {
+					this.editor.events.on(`${eventHandlerName}`, (...args) => {
 						return handler.apply(this.parent, args);
 					});
 				}
 			}
-			this.instance.events.on('blur', (e) => this.value = this.instance.html.get());
-			this.instance.events.on('contentChanged', (e) => this.value = this.instance.html.get());
+			this.editor.events.on('blur', (e) => this.value = this.editor.html.get());
+			this.editor.events.on('contentChanged', (e) => this.value = this.editor.html.get());
 		});
 	}
 
 	// Destroy
 	detached () {
-		if (this.instance != null) {
-			this.instance.destroy();
-			this.instance = null;
+		if (this.editor != null) {
+			this.editor.destroy();
+			this.editor = null;
 		}
 	}
 }

--- a/src/froala-editor.js
+++ b/src/froala-editor.js
@@ -26,7 +26,7 @@ export class FroalaEditor1 {
 		this.observerLocator = observerLocator;
 	}
 
-	// Starting poing.
+	// Starting point.
 	tearUp () {
 		// Get element.
 		if (this.config.iframe) {

--- a/src/froala-editor.js
+++ b/src/froala-editor.js
@@ -17,34 +17,34 @@ export class FroalaEditor1 {
 	instance;
 
 	constructor (element, config, observerLocator) {
-    // Store element.
+		// Store element.
 		this.element = element;
 
-    // Read config.
-    this.config = config.options();
+		// Read config.
+		this.config = config.options();
 
 		this.observerLocator = observerLocator;
 	}
 
-  // Starting poing.
-	  tearUp () {
-    // Get element.
-        if (this.config.iframe) {
-            this.instance = this.element.getElementsByTagName('textarea')[0];
-        }
-        else {
-            this.instance = this.element.getElementsByTagName('div')[0];
-        }
+	// Starting poing.
+	tearUp () {
+		// Get element.
+		if (this.config.iframe) {
+			this.instance = this.element.getElementsByTagName('textarea')[0];
+		}
+		else {
+			this.instance = this.element.getElementsByTagName('div')[0];
+		}
 
-    // Check if editor isn't already initialized.
+		// Check if editor isn't already initialized.
 		if (this.instance['data-froala.editor']) {
 		  return;
 		}
 
-    // Set the HTML for the inner element.
-    this.instance.innerHTML = this.value;
+		// Set the HTML for the inner element.
+		this.instance.innerHTML = this.value;
 
- 		// Observe value.
+		// Observe value.
 		this.subscriptions = [
 			this.observerLocator
 					.getObserver(this, 'value')
@@ -55,7 +55,7 @@ export class FroalaEditor1 {
 					})
 			];
 
-    // Set events.
+		// Set events.
 		if (this.eventHandlers && this.eventHandlers.length != 0) {
 			for(let eventHandlerName in this.eventHandlers) {
 				let handler = this.eventHandlers[eventHandlerName];
@@ -63,31 +63,30 @@ export class FroalaEditor1 {
 					let p = arguments;
 					return handler.apply(this, p)
 				});
-
 			}
 		}
 		this.instance.addEventListener('contentChanged', (e, editor) => this.value = editor.html.get());
 		this.instance.addEventListener('blur', (e, editor) => this.value = editor.html.get())
 
-    // Initialize editor.
+		// Initialize editor.
 		this.instance = new FroalaEditor(`#${this.element.id}`, Object.assign({}, this.config));
 	}
 
-  // Destroy.
+	// Destroy.
 	tearDown () {
 		if (this.instance && this.instance['data-froala.editor']) {
-    	this.instance.destroy();
-  	}
+			this.instance.destroy();
+		}
 
 		this.instance = null;
 	}
 
-  // Setup.
+	// Setup.
 	attached () {
 		this.tearUp();
 	}
 
-  // Destroy.
+	// Destroy.
 	detached () {
 		this.tearDown();
 	}

--- a/src/froala-editor.js
+++ b/src/froala-editor.js
@@ -10,11 +10,11 @@ import FroalaEditor from 'froala-editor/js/froala_editor.pkgd.min.js'
 @inject(Element, Config, ObserverLocator)
 export class FroalaEditor1 {
 	@bindable value;
-	@bindable config = {}
-	@bindable eventHandlers = {}
+	@bindable config = {};
+	@bindable eventHandlers = {};
+  @bindable instance;
 
 	element;
-	instance;
 
 	constructor (element, config, observerLocator) {
 		// Store element.

--- a/src/froala-editor.js
+++ b/src/froala-editor.js
@@ -12,7 +12,7 @@ export class FroalaEditor1 {
 	@bindable value;
 	@bindable config = {};
 	@bindable eventHandlers = {};
-  @bindable instance;
+	@bindable instance;
 
 	parent;
 	element;
@@ -27,7 +27,8 @@ export class FroalaEditor1 {
 		this.observerLocator = observerLocator;
 	}
 
-  bind(bindingContext, overrideContext) {
+	// Get parent context to use in eventhandlers
+	bind(bindingContext, overrideContext) {
 		this.parent = bindingContext;
 	}
 

--- a/src/froala-editor.js
+++ b/src/froala-editor.js
@@ -18,12 +18,8 @@ export class FroalaEditor1 {
 	element;
 
 	constructor (element, config, observerLocator) {
-		// Store element.
 		this.element = element;
-
-		// Read config.
 		this.config = config.options();
-
 		this.observerLocator = observerLocator;
 	}
 
@@ -32,8 +28,8 @@ export class FroalaEditor1 {
 		this.parent = bindingContext;
 	}
 
-	// Starting point.
-	tearUp () {
+	// Setup
+	attached() {
 		// Get element.
 		const editorSelector = this.config.iframe ? 'textarea' : 'div';
 
@@ -70,21 +66,11 @@ export class FroalaEditor1 {
 		});
 	}
 
-	// Destroy.
-	tearDown () {
+	// Destroy
+	detached () {
 		if (this.instance != null) {
 			this.instance.destroy();
 			this.instance = null;
 		}
-	}
-
-	// Setup.
-	attached () {
-		this.tearUp();
-	}
-
-	// Destroy.
-	detached () {
-		this.tearDown();
 	}
 }

--- a/src/froala-editor.js
+++ b/src/froala-editor.js
@@ -46,9 +46,6 @@ export class FroalaEditor1 {
 		  return;
 		}
 
-		// Set the HTML for the inner element.
-		this.instance.innerHTML = this.value;
-
 		// Observe value.
 		this.subscriptions = [
 			this.observerLocator
@@ -62,6 +59,9 @@ export class FroalaEditor1 {
 
 		// Initialize editor.
 		this.instance = new FroalaEditor(`#${this.element.id} div`, Object.assign({}, this.config), () => {
+			// Set initial HTML value.
+			this.instance.html.set(this.value);
+
 			// Set Events
 			if (this.eventHandlers && this.eventHandlers.length != 0) {
 				for(let eventHandlerName in this.eventHandlers) {


### PR DESCRIPTION
Thanks for putting together this component. Made it nice and easy to integrate the froala-editor in v2.9.5. After upgrading to v3, I noticed that a number of things were no longer working. Since I needed this urgently for a project I am working on, I made some updates to aurelia-froala-editor to work nicely with v3. If you approve, can this be merged into the mainstream? Please let me know if any questions or edits needed.

This pull request:
- Fixes event handlers
- Fixes binding of value
- Adds 'editor' as a bindable value in order to set settings in the parent component
- Setup editor on correct component (either div or textarea depending on iframe setting)
- Refactors for additional clarity

Please note, I did not test with the iframe setting set to true.